### PR TITLE
Allow users to set own values for their input

### DIFF
--- a/src/selectbox/selectbox.js
+++ b/src/selectbox/selectbox.js
@@ -155,7 +155,8 @@ angular.module('selectbox', [])
          * @param index
          */
         $scope.selectItem = function(index) {
-
+            var selectedValue = $scope.list[index].value;
+            
             if ($scope.multi) {
 
                 var selectedId = $scope.list[index].id;
@@ -169,6 +170,7 @@ angular.module('selectbox', [])
 
                 } else {
                     $scope.view.selected.push(selectedId);
+                    $scope.selectedValue.push(selectedValue || selectedId);
                 }
 
                 $scope.index = $scope.view.selected;
@@ -176,6 +178,7 @@ angular.module('selectbox', [])
             } else {
                 $scope.view.selected = $scope.list[index];
                 $scope.index = index;
+                $scope.selectedValue = selectedValue || index;
             }
         };
 
@@ -218,7 +221,7 @@ angular.module('selectbox', [])
             replace: true,
             scope: {
                 list: '=',
-                index: '=ngModel',
+                selectedValue: '=ngModel',
                 multi: '@',
                 title: '@',
                 min: '@',


### PR DESCRIPTION
A user may want to have a custom value associated with the selected item rather than its index. This binds ngModel to selectedValue, and then sets selectedValue to the object's value attribute if present, otherwise to the index.
So you can do: { id: 1, name: 'Hello', value: 'World' } to get a binding of Hello=World rather than i.e. Hello=1
